### PR TITLE
Instrument connections with Telemetry

### DIFF
--- a/lib/coap/connection.ex
+++ b/lib/coap/connection.ex
@@ -304,6 +304,12 @@ defmodule CoAP.Connection do
 
     reply(response, state)
 
+    :telemetry.execute(
+      [:coap_ex, :connection, :block_transferred],
+      %{size: byte_size(next_payload.data)},
+      %{message_id: message_id, block_number: number, direction: :send}
+    )
+
     %{state | timer: timer, out_payload: next_payload, message: response}
   end
 
@@ -344,6 +350,12 @@ defmodule CoAP.Connection do
 
     response = %{response | multipart: multipart}
     reply(response, state)
+
+    :telemetry.execute(
+      [:coap_ex, :connection, :block_transferred],
+      %{size: byte_size(message.payload)},
+      %{message_id: message.message_id, block_number: number, direction: :receive}
+    )
 
     %{
       state
@@ -504,19 +516,32 @@ defmodule CoAP.Connection do
     timeout = timeout * 2
     timer = start_timer(timeout)
 
-    # TODO: instrument log/stat for each retry
+    remaining = retries - 1
+
+    :telemetry.execute(
+      [:coap_ex, :connection, :re_tried],
+      %{size: byte_size(message.payload)},
+      %{message_id: message.message_id, remaining_retries: remaining}
+    )
 
     %{
       state
       | phase: :awaiting_peer_ack,
         timer: timer,
         retry_timeout: timeout,
-        retries: retries - 1
+        retries: remaining
     }
   end
 
   defp timeout(state) do
     info("Received timeout: #{inspect(state)}")
+
+    :telemetry.execute(
+      [:coap_ex, :connection, :timed_out],
+      %{},
+      %{message_id: state.message.message_id}
+    )
+
     state
   end
 

--- a/lib/coap/connection.ex
+++ b/lib/coap/connection.ex
@@ -305,9 +305,9 @@ defmodule CoAP.Connection do
     reply(response, state)
 
     :telemetry.execute(
-      [:coap_ex, :connection, :block_transferred],
+      [:coap_ex, :connection, :block_sent],
       %{size: byte_size(next_payload.data)},
-      %{message_id: message_id, block_number: number, direction: :send}
+      %{message_id: message_id, block_number: number}
     )
 
     %{state | timer: timer, out_payload: next_payload, message: response}
@@ -352,9 +352,9 @@ defmodule CoAP.Connection do
     reply(response, state)
 
     :telemetry.execute(
-      [:coap_ex, :connection, :block_transferred],
+      [:coap_ex, :connection, :block_received],
       %{size: byte_size(message.payload)},
-      %{message_id: message.message_id, block_number: number, direction: :receive}
+      %{message_id: message.message_id, block_number: number}
     )
 
     %{

--- a/lib/coap/socket_server.ex
+++ b/lib/coap/socket_server.ex
@@ -200,10 +200,12 @@ defmodule CoAP.SocketServer do
         ref = Process.monitor(conn)
         debug("Started conn: #{inspect(conn)} for #{inspect(connection_id)}")
 
+        {host, port, _} = connection_id
+
         :telemetry.execute(
           [:coap_ex, :connection, :connection_started],
           %{},
-          %{connection_id: connection_id}
+          %{host: host, port: port}
         )
 
         {

--- a/lib/coap/socket_server.ex
+++ b/lib/coap/socket_server.ex
@@ -97,6 +97,12 @@ defmodule CoAP.SocketServer do
   def handle_info({:udp, _socket, peer_ip, peer_port, data}, state) do
     debug("CoAP socket received raw data #{to_hex(data)} from #{inspect({peer_ip, peer_port})}")
 
+    :telemetry.execute(
+      [:coap_ex, :connection, :data_received],
+      %{size: byte_size(data)},
+      %{host: peer_ip, port: peer_port}
+    )
+
     message = Message.decode(data)
 
     {connection, new_state} =
@@ -119,6 +125,12 @@ defmodule CoAP.SocketServer do
 
     debug("CoAP socket sending raw data #{to_hex(data)} to #{inspect({ip, port})}")
 
+    :telemetry.execute(
+      [:coap_ex, :connection, :data_sent],
+      %{size: byte_size(data)},
+      %{host: ip, port: port}
+    )
+
     :gen_udp.send(socket, ip, port, data)
 
     {:noreply, state}
@@ -129,12 +141,21 @@ defmodule CoAP.SocketServer do
     Removes complete connection from the registry and monitoring
   """
   def handle_info({:DOWN, ref, :process, _from, reason}, state) do
-    client?(state)
-    |> case do
-      true -> :client
-      false -> :server
-    end
-    |> connection_complete(ref, reason, state)
+    type =
+      case client?(state) do
+        true -> :client
+        false -> :server
+      end
+
+    {host, port, _} = Map.get(state.monitors, ref)
+
+    :telemetry.execute(
+      [:coap_ex, :connection, :connection_ended],
+      %{},
+      %{type: type, host: host, port: port}
+    )
+
+    connection_complete(type, ref, reason, state)
   end
 
   defp connection_complete(:server, ref, reason, %{monitors: monitors} = state) do
@@ -178,6 +199,12 @@ defmodule CoAP.SocketServer do
         {:ok, conn} = start_connection(self(), state.endpoint, connection_id, state.config)
         ref = Process.monitor(conn)
         debug("Started conn: #{inspect(conn)} for #{inspect(connection_id)}")
+
+        :telemetry.execute(
+          [:coap_ex, :connection, :connection_started],
+          %{},
+          %{connection_id: connection_id}
+        )
 
         {
           conn,

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,8 @@ defmodule Coap.MixProject do
       {:gen_coap, github: "gotthardp/gen_coap", only: [:dev, :test]},
       {:stream_data, "~> 0.1", only: :test},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},
-      {:ex_doc, "~> 0.19", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.19", only: :dev, runtime: false},
+      {:telemetry, "~> 0.4.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -10,4 +10,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.6.2", "e06a7bd2bb6de5145da0dd950070110dce88045351224bd98e84edfdaaf5ffee", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
Adds telemetry and publishes the following connection-related events:

```
[
  [:coap_ex, :connection, :block_sent],
  [:coap_ex, :connection, :block_received],
  [:coap_ex, :connection, :connection_started],
  [:coap_ex, :connection, :connection_ended],
  [:coap_ex, :connection, :data_sent],
  [:coap_ex, :connection, :data_received],
  [:coap_ex, :connection, :re_tried],
  [:coap_ex, :connection, :timed_out]
]
```