### PR TITLE
Fix process leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 coap-*.tar
 
+*.plt
+*.plt.hash

--- a/lib/coap.ex
+++ b/lib/coap.ex
@@ -2,8 +2,6 @@ defmodule CoAP do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     children = [
       {DynamicSupervisor, name: CoAP.SocketServerSupervisor, strategy: :one_for_one},
       {DynamicSupervisor, name: CoAP.HandlerSupervisor, strategy: :one_for_one},

--- a/lib/coap/connection.ex
+++ b/lib/coap/connection.ex
@@ -177,6 +177,7 @@ defmodule CoAP.Connection do
 
     Wrap the adapter and the client in a handler
   """
+  @impl GenServer
   def init([server, {adapter, endpoint}, {ip, port, token} = _peer, config]) do
     {:ok, handler} = start_handler(adapter, endpoint)
 
@@ -211,6 +212,7 @@ defmodule CoAP.Connection do
      |> State.add_options(options)}
   end
 
+  @impl GenServer
   def handle_info({:receive, %Message{} = message}, state) do
     :telemetry.execute(
       [:coap_ex, :connection, :data_received],
@@ -244,6 +246,12 @@ defmodule CoAP.Connection do
   def handle_info({:plug_conn, :sent}, state), do: {:noreply, state}
 
   def handle_info({:tag, tag}, state), do: {:noreply, %{state | tag: tag}}
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    send(state.handler, :connection_end)
+    :ok
+  end
 
   # _TODO: connection timeout, set to original state?
 

--- a/lib/coap/connection.ex
+++ b/lib/coap/connection.ex
@@ -247,12 +247,6 @@ defmodule CoAP.Connection do
 
   def handle_info({:tag, tag}, state), do: {:noreply, %{state | tag: tag}}
 
-  @impl GenServer
-  def terminate(_reason, state) do
-    send(state.handler, :connection_end)
-    :ok
-  end
-
   # _TODO: connection timeout, set to original state?
 
   # def handle_info(:retry, state)
@@ -620,7 +614,7 @@ defmodule CoAP.Connection do
 
   # REQUEST ====================================================================
   defp handle(message, handler, peer) do
-    send(handler, {direction(message), message, peer, self()})
+    send(handler, {direction(message), message, peer})
   end
 
   # RESPOND ====================================================================
@@ -684,7 +678,7 @@ defmodule CoAP.Connection do
       CoAP.HandlerSupervisor,
       {
         CoAP.Handler,
-        [adapter, endpoint]
+        [adapter, endpoint, self()]
       }
     )
   end

--- a/lib/coap/handler.ex
+++ b/lib/coap/handler.ex
@@ -1,21 +1,27 @@
 defmodule CoAP.Handler do
-  use GenServer
-
   @moduledoc """
   Thin wrapper process started for each connection with a given `endpoint` module
   Handles receiving messages from connection via request/response and
     calling the appropriate endpoint functions
   Calls back to the connection with the results of the function call, using :deliver
   """
+  use GenServer
 
+  def child_spec(args) do
+    %{id: __MODULE__, start: {__MODULE__, :start_link, [args]}, restart: :transient}
+  end
+
+  @doc false
   def start_link(args) do
     GenServer.start_link(__MODULE__, args)
   end
 
+  @impl GenServer
   def init([adapter, endpoint]) do
     {:ok, {adapter, endpoint}}
   end
 
+  @impl GenServer
   def handle_info({:request, message, peer, connection}, {adapter, endpoint} = state) do
     adapter.request(message, {endpoint, peer}, connection)
     {:noreply, state}
@@ -31,7 +37,7 @@ defmodule CoAP.Handler do
     {:noreply, state}
   end
 
-  # defp deliver(result, connection) do
-  #   send(connection, {:deliver, result})
-  # end
+  def handle_info(:connection_end, state) do
+    {:stop, :normal, state}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Coap.MixProject do
     [
       # Dev
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
-      {:credo, "~> 1.5"},
+      {:credo, "~> 1.5", only: :dev},
       {:stream_data, "~> 0.1", only: :test},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
 


### PR DESCRIPTION
 Make handler transient
    
For each connection, a Handler process is started, monitored by DynamicSupervisor.
When connection ends, Handler process should stop.
